### PR TITLE
#77: ability to add db options, ex: readPreference

### DIFF
--- a/bin/__tests__/commands/add/client.test.js
+++ b/bin/__tests__/commands/add/client.test.js
@@ -81,10 +81,10 @@ describe('addClient', () => {
 
   describe('returns the new config object if clients are valid', () => {
     let initialConfig = {};
-    const validSourceClient_copy = { ...validSourceClient };
-    const validTargetClient_copy = { ...validTargetClient };
-    validSourceClient_copy.options = {test:true};
-    validTargetClient_copy.options = {test:true};
+    const _validSourceClient = { ...validSourceClient };
+    const _validTargetClient = { ...validTargetClient };
+    _validSourceClient.options = { test: true };
+    _validTargetClient.options = { test: true };
 
     beforeAll(() => {
       initialConfig = { ...getConfig() };
@@ -92,7 +92,7 @@ describe('addClient', () => {
     afterAll(() => { setConfig(initialConfig); });
 
     test('returns the new config object if source is valid', () => {
-      const result = addClient(validSourceClient_copy);
+      const result = addClient(_validSourceClient);
       expect(result.config).not.toBe(undefined);
       expect(result.dataClients).not.toBe(undefined);
       expect(result.dataClients[0].db.name).toBe(validSourceName);
@@ -106,7 +106,7 @@ describe('addClient', () => {
       expect(result.queries).not.toBe(undefined);
     });
     test('returns the new config object if target is valid', () => {
-      const result = addClient(validTargetClient_copy);
+      const result = addClient(_validTargetClient);
       expect(result.config).not.toBe(undefined);
       expect(result.dataClients).not.toBe(undefined);
       expect(result.dataClients[0].db.name).toBe(validTargetName);

--- a/bin/__tests__/commands/add/client.test.js
+++ b/bin/__tests__/commands/add/client.test.js
@@ -81,16 +81,23 @@ describe('addClient', () => {
 
   describe('returns the new config object if clients are valid', () => {
     let initialConfig = {};
+    const validSourceClient_copy = { ...validSourceClient };
+    const validTargetClient_copy = { ...validTargetClient };
+    validSourceClient_copy.options = {test:true};
+    validTargetClient_copy.options = {test:true};
+
     beforeAll(() => {
       initialConfig = { ...getConfig() };
     });
     afterAll(() => { setConfig(initialConfig); });
 
     test('returns the new config object if source is valid', () => {
-      const result = addClient(validSourceClient);
+      const result = addClient(validSourceClient_copy);
       expect(result.config).not.toBe(undefined);
       expect(result.dataClients).not.toBe(undefined);
       expect(result.dataClients[0].db.name).toBe(validSourceName);
+      expect(result.dataClients[0].db.options).not.toBe(undefined);
+      expect(result.dataClients[0].db.options.test).toBe(true);
       expect(result.dataClients[0].db.url).toBe(validUrl);
       expect(result.dataClients[0].family).toBe(validFamily);
       expect(result.dataClients[0].origin).toBe(undefined);
@@ -99,10 +106,12 @@ describe('addClient', () => {
       expect(result.queries).not.toBe(undefined);
     });
     test('returns the new config object if target is valid', () => {
-      const result = addClient(validTargetClient);
+      const result = addClient(validTargetClient_copy);
       expect(result.config).not.toBe(undefined);
       expect(result.dataClients).not.toBe(undefined);
       expect(result.dataClients[0].db.name).toBe(validTargetName);
+      expect(result.dataClients[0].db.options).not.toBe(undefined);
+      expect(result.dataClients[0].db.options.test).toBe(true);
       expect(result.dataClients[0].db.url).toBe(validUrl);
       expect(result.dataClients[0].family).toBe(validFamily);
       expect(result.dataClients[0].origin).toBe(validOrigin);

--- a/bin/lib/config.js
+++ b/bin/lib/config.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const shell = require('shelljs');
 
+const { CFG_ABS_PATH } = require('./constants');
 const {
   getJSONContent,
   validateConfig,
@@ -84,10 +85,9 @@ const getConfig = (_argv = {}) => {
 
 const setConfig = (config = {}) => {
   const isValid = isValidConfigObject(config);
-  const cfgAbsPath = absPathname(__dirname, './../.config.json');
   if (isValid) {
     try {
-      fs.writeFileSync(cfgAbsPath, JSON.stringify(config, null, 2));
+      fs.writeFileSync(CFG_ABS_PATH, JSON.stringify(config, null, 2));
       return true;
     } catch (e) {
       shell.echo(JSON.stringify(e));

--- a/bin/lib/constants.js
+++ b/bin/lib/constants.js
@@ -1,5 +1,7 @@
+const { absPathname } = require('../options/shared');
 
 module.exports = {
-  TEST_NODE_ENV: process.env.NODE_ENV === 'test',
+  CFG_ABS_PATH: absPathname(__dirname, './../.config.json'),
   REQUIRED_CONFIG_KEYS: ['dataClients', 'queries'],
+  TEST_NODE_ENV: process.env.NODE_ENV === 'test',
 };


### PR DESCRIPTION
**bin/lib/config.js**
- moved uri creation logic to constants file as CFG_ABS_PATH

**bin/lib/constants.js** 
- export CFG_ABS_PATH

**bin/commands/add/client.js:**
- edited default message with more elaborate description
- forward the received config options to the dataClients
- after saving, echo the saved CFG_ABS_PATH

**bin/__tests__/commands/add/client.test.js** 
- added tests to cover receiving the new options
